### PR TITLE
Set default min/max value to integer type

### DIFF
--- a/spectro-cluster-eks.tf
+++ b/spectro-cluster-eks.tf
@@ -123,8 +123,8 @@ resource "spectrocloud_cluster_eks" "this" {
       name          = machine_pool.value.name
       update_strategy = try(machine_pool.value.update_strategy, "RollingUpdateScaleOut")
       count         = machine_pool.value.count
-      min           = try(machine_pool.value.min, "")
-      max           = try(machine_pool.value.max, "")
+      min           = try(machine_pool.value.min, machine_pool.value.count)
+      max           = max(try(machine_pool.value.max, machine_pool.value.count), try(machine_pool.value.min, machine_pool.value.count)) # Ensure no accidental min/max inconsistency
       instance_type = machine_pool.value.instance_type
       az_subnets    = machine_pool.value.worker_subnets
       disk_size_gb  = machine_pool.value.disk_size_gb

--- a/spectro-cluster-eks.tf
+++ b/spectro-cluster-eks.tf
@@ -123,8 +123,8 @@ resource "spectrocloud_cluster_eks" "this" {
       name          = machine_pool.value.name
       update_strategy = try(machine_pool.value.update_strategy, "RollingUpdateScaleOut")
       count         = machine_pool.value.count
-      min           = try(machine_pool.value.min, machine_pool.value.count)
-      max           = max(try(machine_pool.value.max, machine_pool.value.count), try(machine_pool.value.min, machine_pool.value.count)) # Ensure no accidental min/max inconsistency
+      min           = try(machine_pool.value.min, machine_pool.value.count) # It is possible for the chosen max to be lesser than the min, or for the count to be out of bounds of min or max. Handle these conditions in the provider for this module or as input validation prior to using this module.
+      max           = try(machine_pool.value.max, machine_pool.value.count)
       instance_type = machine_pool.value.instance_type
       az_subnets    = machine_pool.value.worker_subnets
       disk_size_gb  = machine_pool.value.disk_size_gb


### PR DESCRIPTION
Chose the count value for both defaults to disable this Auto Scaling feature by default, and also to keep count aligned within range of min->max.
Ensure that max >= count >= min