### PR TITLE
docs: added module resources and requirements to  README

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,5 +75,100 @@ trimsuffix(k, ".yaml") => yamldecode(templatefile("config/cluster/${k}", local.p
 
 
 
+# Module Resources & Requirements
 
+## Requirements
 
+| Name | Version |
+|------|---------|
+| <a name="requirement_spectrocloud"></a> [spectrocloud](#requirement\_spectrocloud) | ~> 0.11.0 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_spectrocloud"></a> [spectrocloud](#provider\_spectrocloud) | ~> 0.11.0 |
+
+## Modules
+
+No modules.
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [spectrocloud_addon_deployment.this](https://registry.terraform.io/providers/spectrocloud/spectrocloud/latest/docs/resources/addon_deployment) | resource |
+| [spectrocloud_alert.cluster_health_alerts](https://registry.terraform.io/providers/spectrocloud/spectrocloud/latest/docs/resources/alert) | resource |
+| [spectrocloud_appliance.appliance](https://registry.terraform.io/providers/spectrocloud/spectrocloud/latest/docs/resources/appliance) | resource |
+| [spectrocloud_application.app_deployment](https://registry.terraform.io/providers/spectrocloud/spectrocloud/latest/docs/resources/application) | resource |
+| [spectrocloud_application_profile.app_profile](https://registry.terraform.io/providers/spectrocloud/spectrocloud/latest/docs/resources/application_profile) | resource |
+| [spectrocloud_backup_storage_location.bsl](https://registry.terraform.io/providers/spectrocloud/spectrocloud/latest/docs/resources/backup_storage_location) | resource |
+| [spectrocloud_cloudaccount_aws.account](https://registry.terraform.io/providers/spectrocloud/spectrocloud/latest/docs/resources/cloudaccount_aws) | resource |
+| [spectrocloud_cloudaccount_tencent.account](https://registry.terraform.io/providers/spectrocloud/spectrocloud/latest/docs/resources/cloudaccount_tencent) | resource |
+| [spectrocloud_cluster_edge.this](https://registry.terraform.io/providers/spectrocloud/spectrocloud/latest/docs/resources/cluster_edge) | resource |
+| [spectrocloud_cluster_edge_vsphere.this](https://registry.terraform.io/providers/spectrocloud/spectrocloud/latest/docs/resources/cluster_edge_vsphere) | resource |
+| [spectrocloud_cluster_eks.this](https://registry.terraform.io/providers/spectrocloud/spectrocloud/latest/docs/resources/cluster_eks) | resource |
+| [spectrocloud_cluster_group.clustergroup](https://registry.terraform.io/providers/spectrocloud/spectrocloud/latest/docs/resources/cluster_group) | resource |
+| [spectrocloud_cluster_libvirt.this](https://registry.terraform.io/providers/spectrocloud/spectrocloud/latest/docs/resources/cluster_libvirt) | resource |
+| [spectrocloud_cluster_profile.profile_resource](https://registry.terraform.io/providers/spectrocloud/spectrocloud/latest/docs/resources/cluster_profile) | resource |
+| [spectrocloud_cluster_profile_import.import](https://registry.terraform.io/providers/spectrocloud/spectrocloud/latest/docs/resources/cluster_profile_import) | resource |
+| [spectrocloud_cluster_tke.this](https://registry.terraform.io/providers/spectrocloud/spectrocloud/latest/docs/resources/cluster_tke) | resource |
+| [spectrocloud_cluster_vsphere.this](https://registry.terraform.io/providers/spectrocloud/spectrocloud/latest/docs/resources/cluster_vsphere) | resource |
+| [spectrocloud_macro.macro](https://registry.terraform.io/providers/spectrocloud/spectrocloud/latest/docs/resources/macro) | resource |
+| [spectrocloud_project.project](https://registry.terraform.io/providers/spectrocloud/spectrocloud/latest/docs/resources/project) | resource |
+| [spectrocloud_registry_helm.helm_registry](https://registry.terraform.io/providers/spectrocloud/spectrocloud/latest/docs/resources/registry_helm) | resource |
+| [spectrocloud_registry_oci.oci_registry](https://registry.terraform.io/providers/spectrocloud/spectrocloud/latest/docs/resources/registry_oci) | resource |
+| [spectrocloud_team.project_team](https://registry.terraform.io/providers/spectrocloud/spectrocloud/latest/docs/resources/team) | resource |
+| [spectrocloud_virtual_cluster.virtual_cluster](https://registry.terraform.io/providers/spectrocloud/spectrocloud/latest/docs/resources/virtual_cluster) | resource |
+| [spectrocloud_appliance.this](https://registry.terraform.io/providers/spectrocloud/spectrocloud/latest/docs/data-sources/appliance) | data source |
+| [spectrocloud_application_profile.app_profile](https://registry.terraform.io/providers/spectrocloud/spectrocloud/latest/docs/data-sources/application_profile) | data source |
+| [spectrocloud_backup_storage_location.this](https://registry.terraform.io/providers/spectrocloud/spectrocloud/latest/docs/data-sources/backup_storage_location) | data source |
+| [spectrocloud_cloudaccount_aws.this](https://registry.terraform.io/providers/spectrocloud/spectrocloud/latest/docs/data-sources/cloudaccount_aws) | data source |
+| [spectrocloud_cloudaccount_tencent.this](https://registry.terraform.io/providers/spectrocloud/spectrocloud/latest/docs/data-sources/cloudaccount_tencent) | data source |
+| [spectrocloud_cloudaccount_vsphere.this](https://registry.terraform.io/providers/spectrocloud/spectrocloud/latest/docs/data-sources/cloudaccount_vsphere) | data source |
+| [spectrocloud_cluster.cluster_gps](https://registry.terraform.io/providers/spectrocloud/spectrocloud/latest/docs/data-sources/cluster) | data source |
+| [spectrocloud_cluster.clusters](https://registry.terraform.io/providers/spectrocloud/spectrocloud/latest/docs/data-sources/cluster) | data source |
+| [spectrocloud_cluster.deployment_cluster](https://registry.terraform.io/providers/spectrocloud/spectrocloud/latest/docs/data-sources/cluster) | data source |
+| [spectrocloud_cluster.host_cluster](https://registry.terraform.io/providers/spectrocloud/spectrocloud/latest/docs/data-sources/cluster) | data source |
+| [spectrocloud_cluster_group.cluster_group](https://registry.terraform.io/providers/spectrocloud/spectrocloud/latest/docs/data-sources/cluster_group) | data source |
+| [spectrocloud_cluster_group.vir_cluster_group](https://registry.terraform.io/providers/spectrocloud/spectrocloud/latest/docs/data-sources/cluster_group) | data source |
+| [spectrocloud_cluster_profile.this](https://registry.terraform.io/providers/spectrocloud/spectrocloud/latest/docs/data-sources/cluster_profile) | data source |
+| [spectrocloud_pack.data_packs](https://registry.terraform.io/providers/spectrocloud/spectrocloud/latest/docs/data-sources/pack) | data source |
+| [spectrocloud_pack_simple.app_source_tiers](https://registry.terraform.io/providers/spectrocloud/spectrocloud/latest/docs/data-sources/pack_simple) | data source |
+| [spectrocloud_registry.all_registries](https://registry.terraform.io/providers/spectrocloud/spectrocloud/latest/docs/data-sources/registry) | data source |
+| [spectrocloud_registry.app_registries](https://registry.terraform.io/providers/spectrocloud/spectrocloud/latest/docs/data-sources/registry) | data source |
+| [spectrocloud_role.data_roles](https://registry.terraform.io/providers/spectrocloud/spectrocloud/latest/docs/data-sources/role) | data source |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_accounts"></a> [accounts](#input\_accounts) | n/a | `map(any)` | `{}` | no |
+| <a name="input_alerts"></a> [alerts](#input\_alerts) | n/a | `any` | `{}` | no |
+| <a name="input_appliances"></a> [appliances](#input\_appliances) | n/a | `map(any)` | `{}` | no |
+| <a name="input_application_deployments"></a> [application\_deployments](#input\_application\_deployments) | n/a | `any` | `{}` | no |
+| <a name="input_application_profiles"></a> [application\_profiles](#input\_application\_profiles) | n/a | `any` | `{}` | no |
+| <a name="input_bsls"></a> [bsls](#input\_bsls) | n/a | `map(any)` | `{}` | no |
+| <a name="input_cluster_groups"></a> [cluster\_groups](#input\_cluster\_groups) | n/a | `any` | `{}` | no |
+| <a name="input_cluster_profile_imports"></a> [cluster\_profile\_imports](#input\_cluster\_profile\_imports) | n/a | `list(string)` | `[]` | no |
+| <a name="input_cluster_profile_imports_context"></a> [cluster\_profile\_imports\_context](#input\_cluster\_profile\_imports\_context) | n/a | `string` | `"project"` | no |
+| <a name="input_clusters"></a> [clusters](#input\_clusters) | n/a | `map` | `{}` | no |
+| <a name="input_macros"></a> [macros](#input\_macros) | n/a | `map(any)` | `{}` | no |
+| <a name="input_profiles"></a> [profiles](#input\_profiles) | n/a | `map` | `{}` | no |
+| <a name="input_projects"></a> [projects](#input\_projects) | n/a | `map(any)` | `{}` | no |
+| <a name="input_registries"></a> [registries](#input\_registries) | n/a | `map(any)` | `{}` | no |
+| <a name="input_teams"></a> [teams](#input\_teams) | n/a | `map(any)` | `{}` | no |
+| <a name="input_virtual_clusters"></a> [virtual\_clusters](#input\_virtual\_clusters) | n/a | `any` | `{}` | no |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_debug"></a> [debug](#output\_debug) | n/a |
+| <a name="output_debug_addon_pack_manifests"></a> [debug\_addon\_pack\_manifests](#output\_debug\_addon\_pack\_manifests) | n/a |
+| <a name="output_debug_aws_accounts"></a> [debug\_aws\_accounts](#output\_debug\_aws\_accounts) | n/a |
+| <a name="output_debug_cluster_infra_profiles_map"></a> [debug\_cluster\_infra\_profiles\_map](#output\_debug\_cluster\_infra\_profiles\_map) | n/a |
+| <a name="output_debug_cluster_profile_pack_map"></a> [debug\_cluster\_profile\_pack\_map](#output\_debug\_cluster\_profile\_pack\_map) | not addon specific |
+| <a name="output_debug_cluster_system_profiles_map"></a> [debug\_cluster\_system\_profiles\_map](#output\_debug\_cluster\_system\_profiles\_map) | n/a |
+| <a name="output_debug_libvirt_system"></a> [debug\_libvirt\_system](#output\_debug\_libvirt\_system) | n/a |
+| <a name="output_debug_system_pack_manifests"></a> [debug\_system\_pack\_manifests](#output\_debug\_system\_pack\_manifests) | n/a |

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -2,13 +2,13 @@
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_spectrocloud"></a> [spectrocloud](#requirement\_spectrocloud) | ~> 0.10.0 |
+| <a name="requirement_spectrocloud"></a> [spectrocloud](#requirement\_spectrocloud) | ~> 0.11.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_spectrocloud"></a> [spectrocloud](#provider\_spectrocloud) | 0.10.0 |
+| <a name="provider_spectrocloud"></a> [spectrocloud](#provider\_spectrocloud) | ~> 0.11.0 |
 
 ## Modules
 
@@ -19,15 +19,20 @@ No modules.
 | Name | Type |
 |------|------|
 | [spectrocloud_addon_deployment.this](https://registry.terraform.io/providers/spectrocloud/spectrocloud/latest/docs/resources/addon_deployment) | resource |
+| [spectrocloud_alert.cluster_health_alerts](https://registry.terraform.io/providers/spectrocloud/spectrocloud/latest/docs/resources/alert) | resource |
 | [spectrocloud_appliance.appliance](https://registry.terraform.io/providers/spectrocloud/spectrocloud/latest/docs/resources/appliance) | resource |
+| [spectrocloud_application.app_deployment](https://registry.terraform.io/providers/spectrocloud/spectrocloud/latest/docs/resources/application) | resource |
+| [spectrocloud_application_profile.app_profile](https://registry.terraform.io/providers/spectrocloud/spectrocloud/latest/docs/resources/application_profile) | resource |
 | [spectrocloud_backup_storage_location.bsl](https://registry.terraform.io/providers/spectrocloud/spectrocloud/latest/docs/resources/backup_storage_location) | resource |
 | [spectrocloud_cloudaccount_aws.account](https://registry.terraform.io/providers/spectrocloud/spectrocloud/latest/docs/resources/cloudaccount_aws) | resource |
 | [spectrocloud_cloudaccount_tencent.account](https://registry.terraform.io/providers/spectrocloud/spectrocloud/latest/docs/resources/cloudaccount_tencent) | resource |
 | [spectrocloud_cluster_edge.this](https://registry.terraform.io/providers/spectrocloud/spectrocloud/latest/docs/resources/cluster_edge) | resource |
 | [spectrocloud_cluster_edge_vsphere.this](https://registry.terraform.io/providers/spectrocloud/spectrocloud/latest/docs/resources/cluster_edge_vsphere) | resource |
 | [spectrocloud_cluster_eks.this](https://registry.terraform.io/providers/spectrocloud/spectrocloud/latest/docs/resources/cluster_eks) | resource |
+| [spectrocloud_cluster_group.clustergroup](https://registry.terraform.io/providers/spectrocloud/spectrocloud/latest/docs/resources/cluster_group) | resource |
 | [spectrocloud_cluster_libvirt.this](https://registry.terraform.io/providers/spectrocloud/spectrocloud/latest/docs/resources/cluster_libvirt) | resource |
 | [spectrocloud_cluster_profile.profile_resource](https://registry.terraform.io/providers/spectrocloud/spectrocloud/latest/docs/resources/cluster_profile) | resource |
+| [spectrocloud_cluster_profile_import.import](https://registry.terraform.io/providers/spectrocloud/spectrocloud/latest/docs/resources/cluster_profile_import) | resource |
 | [spectrocloud_cluster_tke.this](https://registry.terraform.io/providers/spectrocloud/spectrocloud/latest/docs/resources/cluster_tke) | resource |
 | [spectrocloud_cluster_vsphere.this](https://registry.terraform.io/providers/spectrocloud/spectrocloud/latest/docs/resources/cluster_vsphere) | resource |
 | [spectrocloud_macro.macro](https://registry.terraform.io/providers/spectrocloud/spectrocloud/latest/docs/resources/macro) | resource |
@@ -35,15 +40,24 @@ No modules.
 | [spectrocloud_registry_helm.helm_registry](https://registry.terraform.io/providers/spectrocloud/spectrocloud/latest/docs/resources/registry_helm) | resource |
 | [spectrocloud_registry_oci.oci_registry](https://registry.terraform.io/providers/spectrocloud/spectrocloud/latest/docs/resources/registry_oci) | resource |
 | [spectrocloud_team.project_team](https://registry.terraform.io/providers/spectrocloud/spectrocloud/latest/docs/resources/team) | resource |
+| [spectrocloud_virtual_cluster.virtual_cluster](https://registry.terraform.io/providers/spectrocloud/spectrocloud/latest/docs/resources/virtual_cluster) | resource |
 | [spectrocloud_appliance.this](https://registry.terraform.io/providers/spectrocloud/spectrocloud/latest/docs/data-sources/appliance) | data source |
+| [spectrocloud_application_profile.app_profile](https://registry.terraform.io/providers/spectrocloud/spectrocloud/latest/docs/data-sources/application_profile) | data source |
 | [spectrocloud_backup_storage_location.this](https://registry.terraform.io/providers/spectrocloud/spectrocloud/latest/docs/data-sources/backup_storage_location) | data source |
 | [spectrocloud_cloudaccount_aws.this](https://registry.terraform.io/providers/spectrocloud/spectrocloud/latest/docs/data-sources/cloudaccount_aws) | data source |
 | [spectrocloud_cloudaccount_tencent.this](https://registry.terraform.io/providers/spectrocloud/spectrocloud/latest/docs/data-sources/cloudaccount_tencent) | data source |
 | [spectrocloud_cloudaccount_vsphere.this](https://registry.terraform.io/providers/spectrocloud/spectrocloud/latest/docs/data-sources/cloudaccount_vsphere) | data source |
+| [spectrocloud_cluster.cluster_gps](https://registry.terraform.io/providers/spectrocloud/spectrocloud/latest/docs/data-sources/cluster) | data source |
 | [spectrocloud_cluster.clusters](https://registry.terraform.io/providers/spectrocloud/spectrocloud/latest/docs/data-sources/cluster) | data source |
+| [spectrocloud_cluster.deployment_cluster](https://registry.terraform.io/providers/spectrocloud/spectrocloud/latest/docs/data-sources/cluster) | data source |
+| [spectrocloud_cluster.host_cluster](https://registry.terraform.io/providers/spectrocloud/spectrocloud/latest/docs/data-sources/cluster) | data source |
+| [spectrocloud_cluster_group.cluster_group](https://registry.terraform.io/providers/spectrocloud/spectrocloud/latest/docs/data-sources/cluster_group) | data source |
+| [spectrocloud_cluster_group.vir_cluster_group](https://registry.terraform.io/providers/spectrocloud/spectrocloud/latest/docs/data-sources/cluster_group) | data source |
 | [spectrocloud_cluster_profile.this](https://registry.terraform.io/providers/spectrocloud/spectrocloud/latest/docs/data-sources/cluster_profile) | data source |
 | [spectrocloud_pack.data_packs](https://registry.terraform.io/providers/spectrocloud/spectrocloud/latest/docs/data-sources/pack) | data source |
+| [spectrocloud_pack_simple.app_source_tiers](https://registry.terraform.io/providers/spectrocloud/spectrocloud/latest/docs/data-sources/pack_simple) | data source |
 | [spectrocloud_registry.all_registries](https://registry.terraform.io/providers/spectrocloud/spectrocloud/latest/docs/data-sources/registry) | data source |
+| [spectrocloud_registry.app_registries](https://registry.terraform.io/providers/spectrocloud/spectrocloud/latest/docs/data-sources/registry) | data source |
 | [spectrocloud_role.data_roles](https://registry.terraform.io/providers/spectrocloud/spectrocloud/latest/docs/data-sources/role) | data source |
 
 ## Inputs
@@ -51,15 +65,21 @@ No modules.
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_accounts"></a> [accounts](#input\_accounts) | n/a | `map(any)` | `{}` | no |
-| <a name="input_alerts"></a> [alerts](#input\_alerts) | n/a | `map(any)` | `{}` | no |
+| <a name="input_alerts"></a> [alerts](#input\_alerts) | n/a | `any` | `{}` | no |
 | <a name="input_appliances"></a> [appliances](#input\_appliances) | n/a | `map(any)` | `{}` | no |
+| <a name="input_application_deployments"></a> [application\_deployments](#input\_application\_deployments) | n/a | `any` | `{}` | no |
+| <a name="input_application_profiles"></a> [application\_profiles](#input\_application\_profiles) | n/a | `any` | `{}` | no |
 | <a name="input_bsls"></a> [bsls](#input\_bsls) | n/a | `map(any)` | `{}` | no |
+| <a name="input_cluster_groups"></a> [cluster\_groups](#input\_cluster\_groups) | n/a | `any` | `{}` | no |
+| <a name="input_cluster_profile_imports"></a> [cluster\_profile\_imports](#input\_cluster\_profile\_imports) | n/a | `list(string)` | `[]` | no |
+| <a name="input_cluster_profile_imports_context"></a> [cluster\_profile\_imports\_context](#input\_cluster\_profile\_imports\_context) | n/a | `string` | `"project"` | no |
 | <a name="input_clusters"></a> [clusters](#input\_clusters) | n/a | `map` | `{}` | no |
 | <a name="input_macros"></a> [macros](#input\_macros) | n/a | `map(any)` | `{}` | no |
 | <a name="input_profiles"></a> [profiles](#input\_profiles) | n/a | `map` | `{}` | no |
 | <a name="input_projects"></a> [projects](#input\_projects) | n/a | `map(any)` | `{}` | no |
 | <a name="input_registries"></a> [registries](#input\_registries) | n/a | `map(any)` | `{}` | no |
 | <a name="input_teams"></a> [teams](#input\_teams) | n/a | `map(any)` | `{}` | no |
+| <a name="input_virtual_clusters"></a> [virtual\_clusters](#input\_virtual\_clusters) | n/a | `any` | `{}` | no |
 
 ## Outputs
 
@@ -69,6 +89,7 @@ No modules.
 | <a name="output_debug_addon_pack_manifests"></a> [debug\_addon\_pack\_manifests](#output\_debug\_addon\_pack\_manifests) | n/a |
 | <a name="output_debug_aws_accounts"></a> [debug\_aws\_accounts](#output\_debug\_aws\_accounts) | n/a |
 | <a name="output_debug_cluster_infra_profiles_map"></a> [debug\_cluster\_infra\_profiles\_map](#output\_debug\_cluster\_infra\_profiles\_map) | n/a |
+| <a name="output_debug_cluster_profile_pack_map"></a> [debug\_cluster\_profile\_pack\_map](#output\_debug\_cluster\_profile\_pack\_map) | not addon specific |
 | <a name="output_debug_cluster_system_profiles_map"></a> [debug\_cluster\_system\_profiles\_map](#output\_debug\_cluster\_system\_profiles\_map) | n/a |
 | <a name="output_debug_libvirt_system"></a> [debug\_libvirt\_system](#output\_debug\_libvirt\_system) | n/a |
 | <a name="output_debug_system_pack_manifests"></a> [debug\_system\_pack\_manifests](#output\_debug\_system\_pack\_manifests) | n/a |


### PR DESCRIPTION
This PR adds the module resources and requirements to the Readme. This will enable the ability for consumers to read the documentation in the Terraform Registry. 

![CleanShot 2023-02-16 at 10 29 52](https://user-images.githubusercontent.com/29551334/219442695-82b2fe6f-0551-4d75-b9ce-cf2e0733874c.png)


Currently, on the docs page, a compatibility chart is maintained. 

![CleanShot 2023-02-16 at 10 25 44](https://user-images.githubusercontent.com/29551334/219441563-b8cbfe20-8fea-4fd3-9c49-9884a90089fb.png)

This is unnecessary as the module's provider block self-documents the required provider version.

```terraform
terraform {
  required_providers {
    spectrocloud = {
      version = "~> 0.11.0"
      source  = "spectrocloud/spectrocloud"
    }
  }
}

```
Instead, the docs page can point to the registry page, which will now include the required provider version in the readme.
